### PR TITLE
Fix: axios interceptor token 관련 로직 수정및 baseUrl 추가

### DIFF
--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,13 +1,19 @@
 import { AUTH_KEY, AUTH_MESSAGE } from '@/constants/auth';
 import { default as axiosDefault } from 'axios';
 import { toast } from 'react-toastify';
+import { deleteCookie, getCookie, setCookie } from 'cookies-next';
 
-const axios = axiosDefault.create();
+const axios = axiosDefault.create({
+  baseURL: process.env.NEXT_PUBLIC_URL,
+  headers: {
+    Authorization: `Bearer ${getCookie(AUTH_KEY.ACCESS_TOKEN)}`,
+  },
+});
 
 const isDev = process.env.NODE_ENV === 'development';
 // 요청 인터셉터
 axios.interceptors.request.use((config) => {
-  let token = localStorage.getItem(
+  let token = getCookie(
     config.url!.includes('token')
       ? AUTH_KEY.REFRESH_TOKEN
       : AUTH_KEY.ACCESS_TOKEN,
@@ -22,15 +28,19 @@ axios.interceptors.request.use((config) => {
 axios.interceptors.response.use(
   (res) => {
     if (res.config.url?.includes('signin')) {
-      localStorage.setItem(AUTH_KEY.ACCESS_TOKEN, res.data.accessToken);
-      localStorage.setItem(AUTH_KEY.REFRESH_TOKEN, res.data.refreshToken);
+      setCookie(AUTH_KEY.ACCESS_TOKEN, res.data.accessToken, {
+        maxAge: 30 * 24 * 60 * 60,
+      });
+      setCookie(AUTH_KEY.REFRESH_TOKEN, res.data.refreshToken, {
+        maxAge: 30 * 24 * 60 * 60,
+      });
     }
     return res;
   },
   async (err) => {
     const { config, request } = err;
 
-    if (request.status === 401) {
+    if (request?.status === 401) {
       // 비 인증 상태 일때
       return await axios
         .post(
@@ -38,16 +48,17 @@ axios.interceptors.response.use(
           {},
           {
             headers: {
-              Authorization: `Bearer ${localStorage.getItem(
-                AUTH_KEY.REFRESH_TOKEN,
-              )}`,
+              Authorization: `Bearer ${getCookie(AUTH_KEY.REFRESH_TOKEN)}`,
             },
           },
         )
         .then((res) => {
           // 비인증 상태에서 성공적으로 토큰이 갱신된 경우
           // 인증 정보를 저정한 이후 다시 요청을 보낸다.
-          localStorage.setItem(AUTH_KEY.ACCESS_TOKEN, res.data.accessToken);
+
+          setCookie(AUTH_KEY.ACCESS_TOKEN, res.data.accessToken, {
+            maxAge: 30 * 24 * 60 * 60,
+          });
 
           config.headers.Authorization = `Bearer ${res.data.accessToken}`;
 
@@ -56,14 +67,15 @@ axios.interceptors.response.use(
         .catch(() => {
           // 비인증 상태에서 요청이 반려된 경우
           // 인증 정보를 제거한다.
-          localStorage.removeItem(AUTH_KEY.ACCESS_TOKEN);
-          localStorage.removeItem(AUTH_KEY.REFRESH_TOKEN);
+
+          deleteCookie(AUTH_KEY.ACCESS_TOKEN);
+          deleteCookie(AUTH_KEY.REFRESH_TOKEN);
           toast.error(AUTH_MESSAGE.REFRESH_ERROR);
           location.replace('/signin');
         });
     }
 
-    isDev && console.error(`요청 에러 ( 에러코드 : ${request.status} ) `, err);
+    isDev && console.error(`요청 에러 ( 에러코드 : ${request?.status} ) `, err);
 
     return Promise.reject(err);
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@tanstack/react-query": "^4.32.6",
     "axios": "^1.4.0",
+    "cookies-next": "^4.0.0",
     "framer-motion": "^10.15.1",
     "msw": "^0.49.0",
     "next": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,6 +201,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.3.tgz#4e4a95b6fe44014563ceb514b2598b3e623d1c98"
   integrity sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==
 
+"@types/node@^16.10.2":
+  version "16.18.50"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.50.tgz#93003cf0251a2ecd26dad6dc757168d648519805"
+  integrity sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==
+
 "@types/prop-types@*":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
@@ -521,10 +526,19 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-cookie@^0.4.2:
+cookie@^0.4.0, cookie@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
+cookies-next@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cookies-next/-/cookies-next-4.0.0.tgz#36d5c0d5899cf729a2580fd065071bdfa13783ca"
+  integrity sha512-3TyzeltFCGgdOlVOVTPClSq+YV9ZCdOyA3aHRZv9f5aSgg7EyI4NSvXFOCgzT/xIxeHR4Rz8/z5Tdo9oPqaVpA==
+  dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/node" "^16.10.2"
+    cookie "^0.4.0"
 
 css-selector-tokenizer@^0.8:
   version "0.8.0"


### PR DESCRIPTION
## 세부 설명

- localstorage 사용시 interceptor 요청 시점이 window가 존재하지 안을때 오류가 발생
  - cookie를 저장소로 사용하는 방법으로 해결했습니다 ( but, 서버에 요청시 같이 넘어가는 sideEffect..)
- axios baseUrl 추가
  - axios interceptor 단에서 401오류 수정시 발생하는 baseUrl의 포트가 생략되는 오류를 해결하기위해 baseUrl을 추가했습니다
