### PR TITLE
Refactor: 로그인 API 스펙 변경에 따른 리펙토링 및 label 수정

### DIFF
--- a/components/views/auth/OwnerSignInView.tsx
+++ b/components/views/auth/OwnerSignInView.tsx
@@ -2,12 +2,12 @@ import Layout from '@/components/auth/layout/SignLayout';
 import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
 import useAuth from '@/hooks/useAuth';
-import { fixFirstCharUpperCase } from '@/lib/fixFirstCharUpperCase';
 import { regx } from '@/lib/regx';
 import { IFormRegister } from '@/types/auth.type';
 import Link from 'next/link';
 
 import { useForm } from 'react-hook-form';
+import fixInputLabel, { IFixInputLabel } from '@/lib/fixInputLabel';
 
 export default function OwnerSignInView() {
   const { signIn } = useAuth();
@@ -19,14 +19,14 @@ export default function OwnerSignInView() {
   } = useForm();
 
   const formRegister: IFormRegister = {
-    email: {
-      type: 'email',
-      placeholder: 'email@queosk.com',
-      ...register('email', {
-        required: '이메일은 필수입니다.',
-        pattern: {
-          value: regx.email,
-          message: '올바른 이메일 형식이 아닙니다.',
+    id: {
+      type: 'text',
+      placeholder: 'ownerId',
+      ...register('onwerId', {
+        required: '아이디는 필수입니다.',
+        minLength: {
+          value: 4,
+          message: 'Id는 4자리 이상이여야 합니다.',
         },
       }),
     },
@@ -56,7 +56,7 @@ export default function OwnerSignInView() {
           {Object.keys(formRegister).map((key) => (
             <Input
               key={`user-sign-in-${key}`}
-              label={fixFirstCharUpperCase(key)}
+              label={fixInputLabel(key as IFixInputLabel)}
               errorText={(errors[key]?.message as string) || ''}
             >
               <Input.Field

--- a/components/views/auth/OwnerSignInView.tsx
+++ b/components/views/auth/OwnerSignInView.tsx
@@ -22,7 +22,7 @@ export default function OwnerSignInView() {
     id: {
       type: 'text',
       placeholder: 'ownerId',
-      ...register('onwerId', {
+      ...register('ownerId', {
         required: '아이디는 필수입니다.',
         minLength: {
           value: 4,

--- a/components/views/auth/OwnerSignUpView.tsx
+++ b/components/views/auth/OwnerSignUpView.tsx
@@ -55,8 +55,8 @@ export default function OwnerSignUpView() {
       ...register('ownerId', {
         required: 'Id는 필수 입니다.',
         minLength: {
-          value: 5,
-          message: 'Id는 5자리 이상이여야 합니다.',
+          value: 4,
+          message: 'Id는 4자리 이상이여야 합니다.',
         },
       }),
     },

--- a/components/views/auth/UserSignInView.tsx
+++ b/components/views/auth/UserSignInView.tsx
@@ -1,14 +1,13 @@
 import { useForm } from 'react-hook-form';
 import { IFormRegister } from '@/types/auth.type';
 import { regx } from '@/lib/regx';
-import { FormEvent } from 'react';
 import SignLayout from '@/components/auth/layout/SignLayout';
 import Button from '@/components/common/Button';
 import { RiKakaoTalkFill } from 'react-icons/ri';
 import Input from '@/components/common/Input';
-import { fixFirstCharUpperCase } from '@/lib/fixFirstCharUpperCase';
 import Link from 'next/link';
 import useAuth from '@/hooks/useAuth';
+import fixInputLabel, { IFixInputLabel } from '@/lib/fixInputLabel';
 
 export default function UserSignInView() {
   const { signIn, OAuthRedirect } = useAuth();
@@ -50,7 +49,7 @@ export default function UserSignInView() {
     await signIn(data, 'user');
   });
 
-  const onClickKAKAOLogin = (e: FormEvent<HTMLButtonElement>) => {
+  const onClickKAKAOLogin = () => {
     OAuthRedirect('kakao');
   };
 
@@ -70,7 +69,7 @@ export default function UserSignInView() {
           {inputItems.map((key) => (
             <Input
               key={`user-sign-in-${key}`}
-              label={fixFirstCharUpperCase(key)}
+              label={fixInputLabel(key as IFixInputLabel)}
               errorText={(errors[key]?.message as string) || ''}
             >
               <Input.Field

--- a/components/views/auth/UserSignUpView.tsx
+++ b/components/views/auth/UserSignUpView.tsx
@@ -5,9 +5,9 @@ import SignLayout from '@/components/auth/layout/SignLayout';
 import { RiKakaoTalkFill } from 'react-icons/ri';
 import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
-import { fixFirstCharUpperCase } from '@/lib/fixFirstCharUpperCase';
 import Link from 'next/link';
 import useAuth from '@/hooks/useAuth';
+import fixInputLabel, { IFixInputLabel } from '@/lib/fixInputLabel';
 
 export default function UserSignUpView() {
   const { signUp, OAuthRedirect } = useAuth();
@@ -62,6 +62,17 @@ export default function UserSignUpView() {
           v === getValues('password') || '비밀번호가 일치지 않습니다.',
       }),
     },
+    phone: {
+      type: 'text',
+      placeholder: '01012341234',
+      ...register('phone', {
+        required: '휴대폰번호는 필수입니다.',
+        pattern: {
+          value: regx.phone,
+          message: '-를 제외하고 입력해주세요!',
+        },
+      }),
+    },
   };
 
   const onClickKAKAOLogin = async () => {
@@ -87,7 +98,7 @@ export default function UserSignUpView() {
           {Object.keys(formRegister).map((key) => (
             <Input
               key={`user-sign-up-${key}`}
-              label={fixFirstCharUpperCase(key)}
+              label={fixInputLabel(key as IFixInputLabel)}
               errorText={(errors[key]?.message as string) || ''}
             >
               <Input.Field

--- a/lib/fixInputLabel.ts
+++ b/lib/fixInputLabel.ts
@@ -1,0 +1,14 @@
+const fixedLabel = {
+  email: '이메일',
+  nickName: '닉네임',
+  password: '비밀번호',
+  passwordCheck: '비밀번호 확인',
+  phone: '전화번호',
+  id: '아이디',
+};
+
+export type IFixInputLabel = keyof typeof fixedLabel;
+
+export default function fixInputLabel(str: IFixInputLabel) {
+  return fixedLabel[str];
+}


### PR DESCRIPTION
## 세부 설명

- 사업자 로그인의 API가 onwerId를 기반으로 로그인함에 따라 수정
- label의 경우 영어를 한글로 변경하는 fix 추가
