### PR TITLE
Hotfix: 카카오 로그인 uri 경로 수정

### DIFF
--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -82,7 +82,9 @@ export default function useAuth() {
       router.replace(
         `https://kauth.kakao.com/oauth/authorize?client_id=${
           process.env.NEXT_PUBLIC_KAKAO_CLIENT || ''
-        }&redirect_uri=http://localhost:3000/auth/kakao/callback&response_type=code`,
+        }&redirect_uri=${
+          process.env.NEXT_PUBLIC_URL || 'http://localhost:3000'
+        }/auth/kakao/callback&response_type=code`,
       );
     }
   };


### PR DESCRIPTION
## 세부 설명

- 리다이렉트가 localhost로 되는 오류 수정